### PR TITLE
Feature/initiative attack order

### DIFF
--- a/src/MysticRiver.Domain/Battle.cs
+++ b/src/MysticRiver.Domain/Battle.cs
@@ -94,8 +94,7 @@ public sealed class Battle
             throw new ArgumentException("Each move must have a different attacker.");
         }
 
-        var first = a.Attacker == Creature1 ? a : b;
-        var second = first == a ? b : a;
+        var (first, second) = DetermineMoveOrder(a, b);
 
         ApplyMoveIfPossible(first);
         ApplyMoveIfPossible(second);
@@ -105,6 +104,23 @@ public sealed class Battle
             creature1Hp: Creature1.CurrentHp,
             creature2Hp: Creature2.CurrentHp,
             finalResult: outcome);
+    }
+
+    private (Move first, Move second) DetermineMoveOrder(Move a, Move b)
+    {
+        if (a.Attacker.Initiative > b.Attacker.Initiative)
+        {
+            return (a, b);
+        }
+        else if (b.Attacker.Initiative > a.Attacker.Initiative)
+        {
+            return (b, a);
+        }
+        else
+        {
+            // If initiatives are equal, default Creature1 going first (deterministic tiebreaker)
+            return ReferenceEquals(a.Attacker, Creature1) ? (a, b) : (b, a);
+        }
     }
 
     private void ValidateMove(Move move, string paramName)

--- a/src/MysticRiver.Domain/Creature.cs
+++ b/src/MysticRiver.Domain/Creature.cs
@@ -5,17 +5,20 @@ public sealed class Creature
     public string Name { get; }
     public int MaxHp { get; }
     public int CurrentHp { get; private set; }
+    public int Initiative { get; }
 
     public bool IsDead => CurrentHp <= 0;
 
-    public Creature(string name, int maxHp)
+    public Creature(string name, int maxHp, int initiative)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxHp);
+        ArgumentOutOfRangeException.ThrowIfNegative(initiative);
 
         Name = name;
         MaxHp = maxHp;
         CurrentHp = maxHp;
+        Initiative = initiative;
     }
 
     public void TakeDamage(int amount)

--- a/test/MysticRiver.UnitTests/DefeatDetectionTests.cs
+++ b/test/MysticRiver.UnitTests/DefeatDetectionTests.cs
@@ -7,7 +7,7 @@ public class CreatureTests
     [Fact]
     public void IsDead_WhenHpAboveZero_ReturnsFalse()
     {
-        var creature = new Creature("Gruk", 100);
+        var creature = new Creature("Gruk", 100, 10);
 
         Assert.False(creature.IsDead);
     }
@@ -15,7 +15,7 @@ public class CreatureTests
     [Fact]
     public void IsDead_WhenHpReducedToZero_ReturnsTrue()
     {
-        var creature = new Creature("Gruk", 100);
+        var creature = new Creature("Gruk", 100, 10);
 
         creature.TakeDamage(100);
 
@@ -25,7 +25,7 @@ public class CreatureTests
     [Fact]
     public void IsDead_WhenDamageExceedsHp_ReturnsTrueAndHpIsZero()
     {
-        var creature = new Creature("Gruk", 50);
+        var creature = new Creature("Gruk", 50, 10);
 
         creature.TakeDamage(200);
 
@@ -36,7 +36,7 @@ public class CreatureTests
     [Fact]
     public void TakeDamage_ReducesHpByAmount()
     {
-        var creature = new Creature("Gruk", 100);
+        var creature = new Creature("Gruk", 100, 10);
 
         creature.TakeDamage(30);
 
@@ -46,7 +46,7 @@ public class CreatureTests
     [Fact]
     public void TakeDamage_WhenAmountIsZero_ThrowsArgumentOutOfRangeException()
     {
-        var creature = new Creature("Gruk", 100);
+        var creature = new Creature("Gruk", 100, 10);
 
         var ex =Assert.Throws<ArgumentOutOfRangeException>(() => creature.TakeDamage(0));
         Assert.Equal("amount", ex.ParamName);
@@ -55,7 +55,7 @@ public class CreatureTests
     [Fact]
     public void TakeDamage_WhenAmountIsNegative_ThrowsArgumentOutOfRangeException()
     {
-        var creature = new Creature("Gruk", 100);
+        var creature = new Creature("Gruk", 100, 10);
 
         var ex = Assert.Throws<ArgumentOutOfRangeException>(() => creature.TakeDamage(-1));
         Assert.Equal("amount", ex.ParamName);
@@ -64,17 +64,21 @@ public class CreatureTests
 
 public class BattleTests
 {
-    private static (Battle battle, Creature p1, Creature p2) CreateBattle(int hp1 = 100, int hp2 = 100)
+    private static (Battle battle, Creature p1, Creature p2) CreateBattle(
+        int hp1 = 100,
+        int hp2 = 100,
+        int initiative1 = 10,
+        int initiative2 = 20)
     {
-        var p1 = new Creature("Creature1", hp1);
-        var p2 = new Creature("Creature2", hp2);
+        var p1 = new Creature("Creature1", hp1, initiative1);
+        var p2 = new Creature("Creature2", hp2, initiative2);
         return (new Battle(p1, p2), p1, p2);
     }
 
     [Fact]
     public void Constructor_WhenCreature1IsNull_ThrowsArgumentNullException()
     {
-        var p2 = new Creature("Creature2", 100);
+        var p2 = new Creature("Creature2", 100, 20);
 
         Assert.Throws<ArgumentNullException>(() => new Battle(null!, p2));
     }
@@ -82,7 +86,7 @@ public class BattleTests
     [Fact]
     public void Constructor_WhenCreature2IsNull_ThrowsArgumentNullException()
     {
-        var p1 = new Creature("Creature1", 100);
+        var p1 = new Creature("Creature1", 100, 10);
 
         Assert.Throws<ArgumentNullException>(() => new Battle(p1, null!));
     }
@@ -90,7 +94,7 @@ public class BattleTests
     [Fact]
     public void Constructor_WhenBothPlayersAreSameInstance_ThrowsArgumentException()
     {
-        var p1 = new Creature("Creature1", 100);
+        var p1 = new Creature("Creature1", 100, 10);
 
         Assert.Throws<ArgumentException>(() => new Battle(p1, p1));
     }
@@ -169,7 +173,7 @@ public class BattleTests
     public void ExecuteAction_WhenAttackerNotInBattle_ThrowsArgumentException()
     {
         var (battle, _, p2) = CreateBattle();
-        var outsider = new Creature("Outsider", 100);
+        var outsider = new Creature("Outsider", 100, 10);
 
         Assert.Throws<ArgumentException>(() => battle.ExecuteAction(outsider, p2, 10));
     }
@@ -178,7 +182,7 @@ public class BattleTests
     public void ExecuteAction_WhenTargetNotInBattle_ThrowsArgumentException()
     {
         var (battle, p1, _) = CreateBattle();
-        var outsider = new Creature("Outsider", 100);
+        var outsider = new Creature("Outsider", 100, 10);
 
         Assert.Throws<ArgumentException>(() => battle.ExecuteAction(p1, outsider, 10));
     }

--- a/test/MysticRiver.UnitTests/ExecuteAttackTests.cs
+++ b/test/MysticRiver.UnitTests/ExecuteAttackTests.cs
@@ -5,10 +5,14 @@ namespace MysticRiver.UnitTests;
 
 public class ExecuteAttackTests
 {
-    private static (Battle battle, Creature p1, Creature p2) CreateBattle(int hp1 = 100, int hp2 = 100)
+    private static (Battle battle, Creature p1, Creature p2) CreateBattle(
+        int hp1 = 100,
+        int hp2 = 100,
+        int initiative1 = 10,
+        int initiative2 = 10)
     {
-        var p1 = new Creature("Creature1", hp1);
-        var p2 = new Creature("Creature2", hp2);
+        var p1 = new Creature("Creature1", hp1, initiative1);
+        var p2 = new Creature("Creature2", hp2, initiative2);
         return (new Battle(p1, p2), p1, p2);
     }
 
@@ -111,7 +115,7 @@ public class ExecuteAttackTests
     public void ExecuteTurn_WithAttackerNotInBattle_ThrowsArgumentException()
     {
         var (battle, p1, p2) = CreateBattle();
-        var outsider = new Creature("Outsider", 100);
+        var outsider = new Creature("Outsider", 100, 10);
 
         var moveA = Move.BasicAttack(p1, p2, 10);
         var moveB = Move.BasicAttack(outsider, p1, 15);

--- a/test/MysticRiver.UnitTests/InitiativeAttackOrderTests.cs
+++ b/test/MysticRiver.UnitTests/InitiativeAttackOrderTests.cs
@@ -1,0 +1,117 @@
+using MysticRiver.Domain;
+
+namespace MysticRiver.UnitTests;
+
+public class InitiativeAttackOrderTests
+{
+    private static (Battle battle, Creature p1, Creature p2) CreateBattle(
+        int hp1 = 100,
+        int hp2 = 100,
+        int initiative1 = 10,
+        int initiative2 = 10)
+    {
+        var p1 = new Creature("Creature1", hp1, initiative1);
+        var p2 = new Creature("Creature2", hp2, initiative2);
+        return (new Battle(p1, p2), p1, p2);
+    }
+
+    [Fact]
+    public void ExecuteTurn_HigherInitiativeAttacksFirst()
+    {
+        var (battle, p1, p2) = CreateBattle(10, 10, initiative1: 1, initiative2: 10);
+
+        var move1 = Move.BasicAttack(p1, p2, 10);
+        var move2 = Move.BasicAttack(p2, p1, 10);
+
+        var result = battle.ExecuteTurn(move1, move2);
+
+        Assert.Equal(0, p1.CurrentHp);
+        Assert.Equal(10, p2.CurrentHp);
+        Assert.True(result.BattleEnded);
+        Assert.NotNull(result.FinalResult);
+        Assert.Equal(p2, result.FinalResult!.Winner);
+        Assert.Equal(p1, result.FinalResult.Loser);
+    }
+
+    [Fact]
+    public void ExecuteTurn_EqualInitiative_Player1ActsFirst()
+    {
+        var (battle, p1, p2) = CreateBattle(10, 10, initiative1: 10, initiative2: 10);
+
+        var move1 = Move.BasicAttack(p1, p2, 10);
+        var move2 = Move.BasicAttack(p2, p1, 10);
+
+        var result = battle.ExecuteTurn(move1, move2);
+
+        Assert.Equal(10, p1.CurrentHp);
+        Assert.Equal(0, p2.CurrentHp);
+        Assert.True(result.BattleEnded);
+        Assert.NotNull(result.FinalResult);
+        Assert.Equal(p1, result.FinalResult!.Winner);
+        Assert.Equal(p2, result.FinalResult.Loser);
+    }
+
+    [Fact]
+    public void ExecuteTurn_EqualInitiative_IsDeterministicWhenMoveArgumentsReversed()
+    {
+        var (battleA, p1A, p2A) = CreateBattle(30, 30, initiative1: 7, initiative2: 7);
+        var (battleB, p1B, p2B) = CreateBattle(30, 30, initiative1: 7, initiative2: 7);
+
+        var a1 = Move.BasicAttack(p1A, p2A, 12);
+        var a2 = Move.BasicAttack(p2A, p1A, 9);
+
+        var b1 = Move.BasicAttack(p1B, p2B, 12);
+        var b2 = Move.BasicAttack(p2B, p1B, 9);
+
+        var resultA = battleA.ExecuteTurn(a1, a2);
+        var resultB = battleB.ExecuteTurn(b2, b1);
+
+        Assert.Equal(resultA.Creature1Hp, resultB.Creature1Hp);
+        Assert.Equal(resultA.Creature2Hp, resultB.Creature2Hp);
+        Assert.Equal(p1A.CurrentHp, p1B.CurrentHp);
+        Assert.Equal(p2A.CurrentHp, p2B.CurrentHp);
+    }
+
+    [Fact]
+    public void ExecuteTurn_HigherInitiative_IsDeterministicWhenMoveArgumentsReversed()
+    {
+        var (battleA, p1A, p2A) = CreateBattle(hp1: 40, hp2: 40, initiative1: 1, initiative2: 10);
+        var (battleB, p1B, p2B) = CreateBattle(hp1: 40, hp2: 40, initiative1: 1, initiative2: 10);
+
+        var a1 = Move.BasicAttack(p1A, p2A, 12);
+        var a2 = Move.BasicAttack(p2A, p1A, 9);
+
+        var b1 = Move.BasicAttack(p1B, p2B, 12);
+        var b2 = Move.BasicAttack(p2B, p1B, 9);
+
+        var resultA = battleA.ExecuteTurn(a1, a2);
+        var resultB = battleB.ExecuteTurn(b2, b1);
+
+        Assert.Equal(resultA.Creature1Hp, resultB.Creature1Hp);
+        Assert.Equal(resultA.Creature2Hp, resultB.Creature2Hp);
+        Assert.Equal(resultA.BattleEnded, resultB.BattleEnded);
+
+        if (resultA.BattleEnded)
+        {
+            Assert.Equal(resultA.FinalResult!.Winner, resultB.FinalResult!.Winner);
+            Assert.Equal(resultA.FinalResult.Loser, resultB.FinalResult.Loser);
+        }
+    }
+
+    [Fact]
+    public void Constructor_WhenInitiativeIsNegative_ThrowsArgumentOutOfRangeException()
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => new Creature("Gruk", 100, -1));
+        Assert.Equal("initiative", ex.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_WhenInitiativeIsZero_AllowsCreation()
+    {
+        var creature = new Creature("Gruk", 100, 0);
+
+        Assert.Equal(0, creature.Initiative);
+        Assert.False(creature.IsDead);
+        Assert.Equal(100, creature.CurrentHp);
+    }
+}


### PR DESCRIPTION
closes #10 

@reviewer With the current implementation, initiative can be 0. I think that is reasonable gameplay-wise because it represents a creature with no speed advantage, but I can change it if we prefer a minimum of 1.